### PR TITLE
Create Global ConstraintContainer

### DIFF
--- a/src/example/index.js
+++ b/src/example/index.js
@@ -1,10 +1,10 @@
 import { Matrix4, Vector4 } from 'lib/cuon-matrix';
 import { getWebGLContext, initShaders } from 'lib/cuon-utils';
 
-import VerletParticle from 'utils/VerletParticle.js';
-import DistanceConstraint from 'utils/Constraint.js';
-import HairStrand from 'utils/Hair.js';
-import HairyObject from 'utils/HairyObject.js';
+import VerletParticle from 'utils/VerletParticle';
+import { ConstraintContainer } from 'utils/Constraint';
+import HairStrand from 'utils/Hair';
+import HairyObject from 'utils/HairyObject';
 import { getModelData, makeNormalMatrixElements } from 'utils/Geometry';
 
 import * as THREE from 'three';
@@ -18,6 +18,9 @@ import CheckerBoard from './check64.png';
 // let theModel = getModelData(new THREE.SphereGeometry(1, 8, 8));
 let theModel = getModelData(new THREE.CubeGeometry());
 // let theModel = getModelData(new THREE.PlaneGeometry());
+
+// Initialize constraint container for global storage of constraints
+const constraintContainer = new ConstraintContainer();
 
 const imageFilename = CheckerBoard;
 
@@ -81,6 +84,7 @@ const cube = new HairyObject({
   modelData: theModel,
   drawHairFunction: drawHair,
   hairDensity: 10,
+  constraintContainer,
 });
 const cubeScale = 2;
 cube.setScale(cubeScale, cubeScale, cubeScale);
@@ -230,6 +234,7 @@ function startForReal(image) {
     let delta = (new Date().getTime() - lastCalledTime) / 1000;
     lastCalledTime = new Date().getTime();
 
+    constraintContainer.solve();
     cube.update(delta);
     render();
 

--- a/src/utils/Constraint.js
+++ b/src/utils/Constraint.js
@@ -1,4 +1,4 @@
-class Constraint {
+export class Constraint {
   constructor(p1, p2) {
     this.particle1 = p1;
     this.particle2 = p2;
@@ -7,7 +7,7 @@ class Constraint {
   solve() {}
 }
 
-class DistanceConstraint extends Constraint {
+export class DistanceConstraint extends Constraint {
   constructor(p1, p2, restDist) {
     super(p1, p2);
     this.restDistance = restDist;
@@ -47,4 +47,20 @@ class DistanceConstraint extends Constraint {
   }
 }
 
-export default DistanceConstraint;
+export class ConstraintContainer {
+  constructor() {
+    this.constraints = [];
+  }
+
+  add(constraint) {
+    this.constraints.push(constraint);
+  }
+
+  solve(iterations = 11) {
+    for (let i = 0; i < 1 + iterations; i++) {
+      for (let j = 0; j < this.constraints.length; j++) {
+        this.constraints[j].solve();
+      }
+    }
+  }
+}

--- a/src/utils/Hair.js
+++ b/src/utils/Hair.js
@@ -1,6 +1,6 @@
 import { Vector3, Matrix4 } from 'lib/cuon-matrix';
 import VerletParticle from 'utils/VerletParticle.js';
-import DistanceConstraint from 'utils/Constraint.js';
+import { DistanceConstraint, ConstraintContainer } from 'utils/Constraint.js';
 
 class HairStrand {
   constructor({
@@ -9,6 +9,7 @@ class HairStrand {
     normal = [1, 1, 1],
     drawFunction = () => {},
     res = 8,
+    constraintContainer,
   }) {
     this.length = length;
     const [base_x, base_y, base_z] = base;
@@ -20,7 +21,6 @@ class HairStrand {
     //additionally, one unit on the normal is one unit on the length
     this.num_control_vertices = res; //this will create n-1 control hair segments
     this.verlet_parts = [];
-    this.constraints = [];
     this.bezier_control_vertices = [];
     this.final_vertices;
     this.draw = drawFunction;
@@ -44,15 +44,17 @@ class HairStrand {
       }
     }
 
-    let dist = length / (this.num_control_vertices - 1);
-    for (let i = 0; i < this.verlet_parts.length - 1; i++) {
-      this.constraints.push(
-        new DistanceConstraint(
-          this.verlet_parts[i],
-          this.verlet_parts[i + 1],
-          dist
-        )
-      );
+    if (constraintContainer) {
+      let dist = length / (this.num_control_vertices - 1);
+      for (let i = 0; i < this.verlet_parts.length - 1; i++) {
+        constraintContainer.add(
+          new DistanceConstraint(
+            this.verlet_parts[i],
+            this.verlet_parts[i + 1],
+            dist
+          )
+        );
+      }
     }
 
     this.generateBezierControlVertices();
@@ -71,9 +73,6 @@ class HairStrand {
     //update all verlet particles
     for (let i = 0; i < this.num_control_vertices; i++) {
       this.verlet_parts[i].update(delta_t);
-    }
-    for (let i = 0; i < this.constraints.length; i++) {
-      this.constraints[i].solve();
     }
     this.generateBezierControlVertices();
     this.final_vertices = this.generateFinalVertices(this.num_control_vertices); //8 is the number of verts between each pair of control points

--- a/src/utils/HairyObject.js
+++ b/src/utils/HairyObject.js
@@ -1,8 +1,8 @@
 import { Matrix4 } from 'lib/cuon-matrix';
 import CS336Object from './CS336Object';
 import HairStrand from './Hair';
-import DistanceConstraint from './Constraint.js';
 import ChildHair from './ChildHair';
+import { ConstraintContainer } from './Constraint';
 
 export default class HairyObject extends CS336Object {
   constructor({
@@ -10,6 +10,7 @@ export default class HairyObject extends CS336Object {
     modelData = {},
     drawHairFunction = () => {},
     hairDensity = 0,
+    constraintContainer,
   }) {
     super(drawFunction);
     const {
@@ -32,12 +33,19 @@ export default class HairyObject extends CS336Object {
       normals,
       vertexNormals,
       drawHairFunction,
+      constraintContainer,
     });
     this.generateChildHairs({ hairDensity, vertices });
   }
 
   // hashmap the vertices to aggregate the vertex pairs
-  generateHairs({ numVertices, vertices, normals, vertexNormals }) {
+  generateHairs({
+    numVertices,
+    vertices,
+    normals,
+    vertexNormals,
+    constraintContainer,
+  }) {
     let vertexMap = {};
     for (let i = 0; i < numVertices; i++) {
       let [a, b, c] = vertices.slice(3 * i, 3 * i + 3);
@@ -81,7 +89,7 @@ export default class HairyObject extends CS336Object {
         normal: avgNormal,
         drawFunction: this.drawHairFunction,
         res: this.res,
-        constr_list: this.constraints,
+        constraintContainer,
       });
       this.hairs.push(hairStrand);
       this.hairMap[this.vertexToKey(v_base)] = hairStrand;
@@ -106,7 +114,6 @@ export default class HairyObject extends CS336Object {
           new ChildHair(parents, {
             drawFunction: this.drawHairFunction,
             res: this.res,
-            constr_list: this.constraints,
           })
         );
       }


### PR DESCRIPTION
Instead of storing the global constraints in an array, store them in a global `ConstraintContainer` that automatically iterates through solving cycles of all its constraints when `ConstraintContainer.solve()` is called.