### PR TITLE
Pearl Constraints & Hair Trailing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>
+    <h3 id="fps_tracker" style="z-index: 10; color: red; position:absolute;"></h3>
     <div id="root"></div>
   </body>
 </html>

--- a/src/example/index.js
+++ b/src/example/index.js
@@ -16,7 +16,7 @@ import FSHADER_SOURCE_LINES from './fshader_lines.glsl';
 import CheckerBoard from './check64.png';
 
 // let theModel = getModelData(new THREE.SphereGeometry(1, 8, 8));
-let theModel = getModelData(new THREE.CubeGeometry());
+ let theModel = getModelData(new THREE.CubeGeometry(1, 1, 1, 2, 2, 2));
 // let theModel = getModelData(new THREE.PlaneGeometry());
 
 // Initialize constraint container for global storage of constraints
@@ -66,9 +66,9 @@ let lightPosition = new Vector4([-4, 4, 4, 1]);
 
 //view matrix
 let view = new Matrix4().setLookAt(
-  10,
   5,
-  10, // eye
+  5,
+  5, // eye
   0,
   0,
   0, // at - looking at the origin
@@ -83,7 +83,7 @@ const cube = new HairyObject({
   drawFunction: drawCube,
   modelData: theModel,
   drawHairFunction: drawHair,
-  hairDensity: 10,
+  hairDensity: 50,
   constraintContainer,
 });
 const cubeScale = 2;
@@ -120,7 +120,6 @@ function handleKeyPress(event) {
 
 function render() {
   gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BIT);
-
   cube.render();
 }
 
@@ -225,7 +224,9 @@ function startForReal(image) {
 
   gl.enable(gl.DEPTH_TEST);
 
+  //final setup for demo
   let lastCalledTime;
+  constraintContainer.generatePPConstraints(cube.getParticles(false));
 
   // define an animation loop
   function animate(timestamp) {

--- a/src/utils/ChildHair.js
+++ b/src/utils/ChildHair.js
@@ -63,6 +63,6 @@ export default class ChildHair extends HairStrand {
     }
     // generate curves based on interpolated vertices
     this.generateBezierControlVertices();
-    this.final_vertices = this.generateFinalVertices(this.num_control_vertices); //8 is the number of verts between each pair of control points
+    this.final_vertices = this.generateFinalVertices(this.bezier_resolution); //8 is the number of verts between each pair of control points
   }
 }

--- a/src/utils/Constraint.js
+++ b/src/utils/Constraint.js
@@ -47,6 +47,49 @@ export class DistanceConstraint extends Constraint {
   }
 }
 
+// Describes a constraint in which two particles must be
+export class PearlPearlConstraint extends Constraint {
+  constructor(p1, p2) {
+    super(p1, p2);
+  }
+
+  solve() {
+    let diff_x =
+      this.particle1.position.elements[0] - this.particle2.position.elements[0];
+    let diff_y =
+      this.particle1.position.elements[1] - this.particle2.position.elements[1];
+    let diff_z =
+      this.particle1.position.elements[2] - this.particle2.position.elements[2];
+    let distance = Math.sqrt(
+      diff_x * diff_x + diff_y * diff_y + diff_z * diff_z
+    );
+    let minDist = this.particle1.pearl_radius + this.particle2.pearl_radius;
+    if(distance < minDist){
+      let scale = (minDist - distance) / distance;
+      let t_x = diff_x * 0.5 * scale;
+      let t_y = diff_y * 0.5 * scale;
+      let t_z = diff_z * 0.5 * scale;
+
+      if (!this.particle1.fixed_pos) {
+        this.particle1.position.elements[0] =
+          this.particle1.position.elements[0] + t_x;
+        this.particle1.position.elements[1] =
+          this.particle1.position.elements[1] + t_y;
+        this.particle1.position.elements[2] =
+          this.particle1.position.elements[2] + t_z;
+      }
+      if (!this.particle2.fixed_pos) {
+        this.particle2.position.elements[0] =
+          this.particle2.position.elements[0] - t_x;
+        this.particle2.position.elements[1] =
+          this.particle2.position.elements[1] - t_y;
+        this.particle2.position.elements[2] =
+          this.particle2.position.elements[2] - t_z;
+      }
+    }
+  }
+}
+
 export class ConstraintContainer {
   constructor() {
     this.constraints = [];
@@ -56,8 +99,19 @@ export class ConstraintContainer {
     this.constraints.push(constraint);
   }
 
-  solve(iterations = 11) {
-    for (let i = 0; i < 1 + iterations; i++) {
+  generatePPConstraints(particles){
+    let sum = 0
+    for(let i = 0; i < particles.length; i++){
+      for(let j = i + 1; j < particles.length; j++){
+        this.add(new PearlPearlConstraint(particles[i], particles[j]));
+        sum++;
+      }
+    }
+    console.log(sum);
+  }
+
+  solve(iterations = 1) { //i think 11 is too many, reduced to 5 iterations default
+    for (let i = 0; i < iterations; i++) {
       for (let j = 0; j < this.constraints.length; j++) {
         this.constraints[j].solve();
       }

--- a/src/utils/Constraint.js
+++ b/src/utils/Constraint.js
@@ -100,17 +100,14 @@ export class ConstraintContainer {
   }
 
   generatePPConstraints(particles){
-    let sum = 0
     for(let i = 0; i < particles.length; i++){
       for(let j = i + 1; j < particles.length; j++){
         this.add(new PearlPearlConstraint(particles[i], particles[j]));
-        sum++;
       }
     }
-    console.log(sum);
   }
 
-  solve(iterations = 1) { //i think 11 is too many, reduced to 5 iterations default
+  solve(iterations = 5) { //i think 11 is too many, reduced to 5 iterations default
     for (let i = 0; i < iterations; i++) {
       for (let j = 0; j < this.constraints.length; j++) {
         this.constraints[j].solve();

--- a/src/utils/Hair.js
+++ b/src/utils/Hair.js
@@ -36,14 +36,20 @@ class HairStrand {
       let temp_z =
         (i / (this.num_control_vertices - 1)) * normal_z * length + base_z;
       //TODO: i just got thinking that there might be an issue here with the whole normal * length thing
-      let pearl_radius = 0.06 + (0.06 * i / (this.num_control_vertices - 1));
+      let pearl_radius = 0.1 + (0.1 * i / (this.num_control_vertices - 1));
+
+      temp_x += this.getRandomWiggle(0.02);
+      temp_y += this.getRandomWiggle(0.02);
+      temp_z += this.getRandomWiggle(0.02);
+      let dampen_factor = 0.96 + this.getRandomWiggle(0.06);
+      pearl_radius += this.getRandomWiggle(0.02);
       if (i == 0) {
         this.verlet_parts.push(
-          new VerletParticle(temp_x, temp_y, temp_z, true, 0.96, pearl_radius)
+          new VerletParticle(temp_x, temp_y, temp_z, true, dampen_factor, pearl_radius)
         );
       } else {
         this.verlet_parts.push(
-          new VerletParticle(temp_x, temp_y, temp_z, false, 0.96, pearl_radius)
+          new VerletParticle(temp_x, temp_y, temp_z, false, dampen_factor, pearl_radius)
         );
       }
     }
@@ -79,12 +85,12 @@ class HairStrand {
       this.verlet_parts[i].update(delta_t);
     }
     this.generateBezierControlVertices();
-    this.final_vertices = this.generateFinalVertices(this.num_control_vertices); //8 is the number of verts between each pair of control points
+    this.final_vertices = this.generateFinalVertices(this.bezier_resolution); //8 is the number of verts between each pair of control points
   }
 
   render(matrixWorld) {
     const currentWorld = new Matrix4(matrixWorld);
-    this.draw(currentWorld);
+    this.draw(matrixWorld);
   }
 
   generateBezierControlVertices() {

--- a/src/utils/Hair.js
+++ b/src/utils/Hair.js
@@ -24,6 +24,9 @@ class HairStrand {
     this.bezier_control_vertices = [];
     this.final_vertices;
     this.draw = drawFunction;
+    this.bezier_resolution = 4; //this is the number of final vertices between each control vertex
+    //4 is smooth enough for shorter hairs
+    //TODO: make this a parameter
 
     for (let i = 0; i < this.num_control_vertices; i++) {
       let temp_x =
@@ -33,13 +36,14 @@ class HairStrand {
       let temp_z =
         (i / (this.num_control_vertices - 1)) * normal_z * length + base_z;
       //TODO: i just got thinking that there might be an issue here with the whole normal * length thing
+      let pearl_radius = 0.06 + (0.06 * i / (this.num_control_vertices - 1));
       if (i == 0) {
         this.verlet_parts.push(
-          new VerletParticle(temp_x, temp_y, temp_z, true, 0.99)
+          new VerletParticle(temp_x, temp_y, temp_z, true, 0.96, pearl_radius)
         );
       } else {
         this.verlet_parts.push(
-          new VerletParticle(temp_x, temp_y, temp_z, false, 0.99)
+          new VerletParticle(temp_x, temp_y, temp_z, false, 0.96, pearl_radius)
         );
       }
     }
@@ -58,7 +62,7 @@ class HairStrand {
     }
 
     this.generateBezierControlVertices();
-    this.final_vertices = this.generateFinalVertices(this.num_control_vertices); //8 is the number of verts between each pair of control points
+    this.final_vertices = this.generateFinalVertices(this.bezier_resolution);
   }
 
   getRandomWiggle(range) {

--- a/src/utils/HairyObject.js
+++ b/src/utils/HairyObject.js
@@ -24,7 +24,7 @@ export default class HairyObject extends CS336Object {
     this.hairs = [];
     this.childHairs = [];
     this.constraints = [];
-    this.res = 3; // set at 3 for now to improve render times
+    this.res = 5; //5 is a good medium between fast and smooth
     this.drawHairFunction = drawHairFunction;
 
     this.generateHairs({
@@ -85,6 +85,7 @@ export default class HairyObject extends CS336Object {
       ];
 
       const hairStrand = new HairStrand({
+        length: 2.5,
         base: v_base,
         normal: avgNormal,
         drawFunction: this.drawHairFunction,
@@ -150,5 +151,24 @@ export default class HairyObject extends CS336Object {
     for (let i = 0; i < this.childHairs.length; i++) {
       this.childHairs[i].render(currentWorld);
     }
+  }
+
+  getParticles(includeChild){
+    let output = [];
+    for(let i = 0; i < this.hairs.length; i++){
+      let temp = this.hairs[i].verlet_parts;
+      for(let j = 0; j < temp.length; j++){
+        output.push(temp[j]);
+      }
+    }
+    if(includeChild){
+      for(let i = 0; i < this.childHairs.length; i++){
+        let temp = this.childHairs[i].verlet_parts;
+        for(let j = 0; j < temp.length; j++){
+          output.push(temp[j]);
+        }
+      }
+    }
+    return output;
   }
 }

--- a/src/utils/HairyObject.js
+++ b/src/utils/HairyObject.js
@@ -1,4 +1,5 @@
 import { Matrix4 } from 'lib/cuon-matrix';
+import { Vector3 } from 'lib/cuon-matrix';
 import CS336Object from './CS336Object';
 import HairStrand from './Hair';
 import ChildHair from './ChildHair';
@@ -146,10 +147,11 @@ export default class HairyObject extends CS336Object {
     super.render(matrixWorld);
     const currentWorld = new Matrix4(matrixWorld).multiply(this.getMatrix());
     for (let i = 0; i < this.hairs.length; i++) {
-      this.hairs[i].render(currentWorld);
+      this.hairs[i].render(matrixWorld);
+      this.hairs[i].rebase(...currentWorld.multiplyVector3(new Vector3(this.hairs[i].base)).elements);
     }
     for (let i = 0; i < this.childHairs.length; i++) {
-      this.childHairs[i].render(currentWorld);
+      this.childHairs[i].render(matrixWorld);
     }
   }
 
@@ -159,14 +161,6 @@ export default class HairyObject extends CS336Object {
       let temp = this.hairs[i].verlet_parts;
       for(let j = 0; j < temp.length; j++){
         output.push(temp[j]);
-      }
-    }
-    if(includeChild){
-      for(let i = 0; i < this.childHairs.length; i++){
-        let temp = this.childHairs[i].verlet_parts;
-        for(let j = 0; j < temp.length; j++){
-          output.push(temp[j]);
-        }
       }
     }
     return output;

--- a/src/utils/VerletParticle.js
+++ b/src/utils/VerletParticle.js
@@ -2,13 +2,14 @@ import { Vector3 } from 'lib/cuon-matrix';
 import Vector from 'utils/Vector';
 //a particle to represent a point in a hair strand simulated using verlet integration
 class VerletParticle {
-  constructor(base_x, base_y, base_z, anchored, damping) {
+  constructor(base_x, base_y, base_z, anchored, damping, p_size) {
     this.position = new Vector3([base_x, base_y, base_z]);
     this.prevPosition = new Vector3([base_x, base_y, base_z]);
     this.velocity = new Vector3();
     this.acceleration = new Vector3();
     this.fixed_pos = anchored;
     this.dampen_factor = damping;
+    this.pearl_radius = p_size; //the radius of the collision sphere //TODO: make this a passed parameter
     if (this.fixed_pos) this.acceleration = new Vector3();
     else this.acceleration = new Vector3([0, -9.81, 0]);
   }

--- a/src/utils/VerletParticle.js
+++ b/src/utils/VerletParticle.js
@@ -29,8 +29,6 @@ class VerletParticle {
   }
 
   interpolate({ weights: [b_A, b_B, b_C], parents: [p_A, p_B, p_C] }) {
-    if (this.fixed_pos) return;
-
     let pA_pos = new Vector(p_A.position.elements).scale(b_A);
     let pB_pos = new Vector(p_B.position.elements).scale(b_B);
     let pC_pos = new Vector(p_C.position.elements).scale(b_C);


### PR DESCRIPTION
![screen shot 2018-11-28 at 4 21 44 pm](https://user-images.githubusercontent.com/25187025/49186290-d0f92e00-f329-11e8-8c04-72727416c823.png)

This is hair trailing demonstrated on a spherical wireframe object. You can see the incredibly high FPS in the upper left hand corner.

![screen shot 2018-11-28 at 4 26 02 pm](https://user-images.githubusercontent.com/25187025/49186466-554bb100-f32a-11e8-9ff8-92e1752108d7.png)

Additionally present in this demo is the new Pearl Constraints, which allow hairs to collide with themselves and other hairs. You can see in the above image how the top hairs collide with the base of the lower hairs, causing them to be pushed out a little bit. The radius of the pearls gets larger towards the ends of the hair. This effect happens only on the control hairs to conserve on computations, but it is still extremely expensive. With 200 control hairs each with 7 control vertices (approx. what they had in the Nalu Nvidia demo) there are ~1 million constraint checks every Verlet iteration. Expensive indeed.

After seeing multiple configurations with their respective FPS, I think that maybe we could optimize the line rendering by combining multiple hairs with each glDraw call. Not sure how much it would help, just an idea. We would have to move away from gl.LINE_STRIP to gl.LINE which means reworking the final_vertices calculations.

